### PR TITLE
Zephyr: add several SM tests

### DIFF
--- a/bot/config.py.zephyr.sample
+++ b/bot/config.py.zephyr.sample
@@ -87,15 +87,32 @@ z['iut_config'] = {
     "prj.conf": {},  # Default config file name
 
     "privacy.conf": {
+        "enforce_mitm.conf": {
+        "overlay": {'CONFIG_BT_SMP_ENFORCE_MITM': 'y'},
+        "test_cases": ['SM/SLA/PKE/BV-05-C',
+                       'SM/SLA/SCPK/BI-04-C',
+                       'GAP/SEC/AUT/BV-12-C',
+                       'GAP/SEC/AUT/BV-13-C'
+                       ]
+    },
+    "privacy.conf": {
         "overlay": {'CONFIG_BT_PRIVACY': 'y'},
-        "test_cases": ['GAP/PRIV/CONN/BV-10-C', 'GAP/DISC/LIMM/BV-03-C',
-                       'GAP/DISC/GENM/BV-03-C', 'GAP/CONN/NCON/BV-02-C',
-                       'GAP/CONN/NCON/BV-03-C', 'GAP/CONN/UCON/BV-06-C',
-                       'SM/SLA/KDU/BV-02-C', 'SM/MAS/KDU/BV-05-C',
-                       'GAP/CONN/ACEP/BV-03-C', 'GAP/CONN/DCEP/BV-05-C',
-                       'GAP/CONN/GCEP/BV-05-C', 'GAP/BROB/BCST/BV-03-C',
-                       'GAP/PRIV/CONN/BI-01-C', 'GAP/BROB/OBSV/BV-06-C',
-                       'GAP/PRIV/CONN/BV-11-C']},
+        "test_cases": ['GAP/PRIV/CONN/BV-10-C',
+                       'GAP/PRIV/CONN/BV-11-C',
+                       'GAP/CONN/ACEP/BV-03-C', # As of PTS v7.6.2, not supported
+                       'GAP/CONN/DCEP/BV-05-C', # As of PTS v7.6.2, not supported
+                       'GAP/CONN/GCEP/BV-05-C', # As of PTS v7.6.2, not supported
+                       'GAP/CONN/NCON/BV-02-C',
+                       'GAP/CONN/UCON/BV-06-C',
+                       'GAP/BROB/BCST/BV-03-C',
+                       'GAP/BROB/OBSV/BV-06-C',
+                       'SM/MAS/KDU/BV-05-C',
+                       'SM/MAS/KDU/BV-10-C',
+                       'SM/MAS/KDU/BV-11-C',
+                       'SM/SLA/KDU/BV-02-C',
+                       'SM/SLA/KDU/BV-08-C',
+                       ]
+    },
 
     "mesh_subnet_count.conf": {
         "overlay": {'CONFIG_BT_MESH_SUBNET_COUNT': '1'},

--- a/ptsprojects/zephyr/sm.py
+++ b/ptsprojects/zephyr/sm.py
@@ -310,6 +310,46 @@ def test_cases(pts):
                   pre_conditions +
                   [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
                   generic_wid_hdl=sm_wid_hdl),
+        ZTestCase("SM", "SM/MAS/KDU/BV-10-C",
+                  pre_conditions +
+                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
+                  generic_wid_hdl=sm_wid_hdl),
+        ZTestCase("SM", "SM/MAS/KDU/BV-11-C",
+                  pre_conditions +
+                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
+                  generic_wid_hdl=sm_wid_hdl),
+        ZTestCase("SM", "SM/MAS/SCJW/BI-01-C",
+                  pre_conditions +
+                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
+                  generic_wid_hdl=sm_wid_hdl),
+        ZTestCase("SM", "SM/SLA/KDU/BV-08-C",
+                  pre_conditions +
+                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
+                  generic_wid_hdl=sm_wid_hdl),
+        ZTestCase("SM", "SM/SLA/KDU/BV-09-C",
+                  pre_conditions +
+                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
+                  generic_wid_hdl=sm_wid_hdl),
+        ZTestCase("SM", "SM/SLA/SCJW/BI-02-C",
+                  pre_conditions +
+                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
+                  generic_wid_hdl=sm_wid_hdl),
+        ZTestCase("SM", "SM/SLA/SCPK/BV-02-C",
+                  pre_conditions +
+                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
+                  generic_wid_hdl=sm_wid_hdl),
+        ZTestCase("SM", "SM/SLA/SCPK/BV-03-C",
+                  pre_conditions +
+                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
+                  generic_wid_hdl=sm_wid_hdl),
+        ZTestCase("SM", "SM/SLA/SCPK/BI-03-C",
+                  pre_conditions +
+                  [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],
+                  generic_wid_hdl=sm_wid_hdl),
+        ZTestCase("SM", "SM/SLA/SCPK/BI-04-C",
+                  pre_conditions +
+                  [TestFunc(btp.gap_set_io_cap, IOCap.keyboard_only)],
+                  generic_wid_hdl=sm_wid_hdl),
         ZTestCase("SM", "SM/SLA/KDU/BI-01-C",
                   pre_conditions +
                   [TestFunc(btp.gap_set_io_cap, IOCap.display_only)],

--- a/ptsprojects/zephyr/sm_wid.py
+++ b/ptsprojects/zephyr/sm_wid.py
@@ -38,8 +38,6 @@ def sm_wid_hdl(wid, description, test_case_name):
 # wid handlers section begin
 def hdl_wid_100(desc):
     btp.gap_conn()
-    btp.gap_wait_for_connection()
-    btp.gap_pair()
     return True
 
 


### PR DESCRIPTION
added support for tests:
-SM/MAS/KDU/BV-10-C
-SM/MAS/KDU/BV-11-C
-SM/MAS/SCJW/BI-01-C
-SM/SLA/KDU/BV-08-C
-SM/SLA/KDU/BV-09-C
-SM/SLA/SCJW/BI-02-C
-SM/SLA/SCPK/BI-03-C
-SM/SLA/SCPK/BI-04-C
-SM/SLA/SCPK/BV-02-C
-SM/SLA/SCPK/BV-03-C