### PR TITLE
Zephyr: fix GAP_CONN_UCON_BV_06_C.

### DIFF
--- a/bot/config.py.zephyr.sample
+++ b/bot/config.py.zephyr.sample
@@ -99,7 +99,7 @@ z['iut_config'] = {
     },
 
     "privacy.conf": {
-        "overlay": {'CONFIG_BT_PRIVACY': 'y'},
+        "overlay": {'CONFIG_BT_PRIVACY': 'y', 'CONFIG_BT_RPA_TIMEOUT': '5'},
         "test_cases": ['GAP/PRIV/CONN/BV-10-C',
                        'GAP/PRIV/CONN/BV-11-C',
                        'GAP/CONN/ACEP/BV-03-C', # As of PTS v7.6.2, not supported

--- a/ptsprojects/zephyr/gap.py
+++ b/ptsprojects/zephyr/gap.py
@@ -138,7 +138,7 @@ def set_pixits(pts):
     pts.set_pixit("GAP", "TSPX_gen_disc_scan_min", "10240")
     pts.set_pixit("GAP", "TSPX_database_file", "Database-GAP.sig")
     pts.set_pixit("GAP", "TSPX_iut_rx_mtu", "23")
-    pts.set_pixit("GAP", "TSPX_iut_private_address_interval", "60000")
+    pts.set_pixit("GAP", "TSPX_iut_private_address_interval", "5000")
     pts.set_pixit("GAP", "TSPX_iut_privacy_enabled", "FALSE")
     pts.set_pixit("GAP", "TSPX_psm", "1001")
     pts.set_pixit("GAP", "TSPX_iut_valid_connection_interval_min", "00C8")


### PR DESCRIPTION
Set correct RPA timeout to 5 seconds.

Signed-off-by: Sondre Ravn <sondre.ravn@nordicsemi.no>