### PR TITLE
wid: Fix GAP WID #52 that IUT is in Undirected Connectable Mode

### DIFF
--- a/ptsprojects/zephyr/gap_wid.py
+++ b/ptsprojects/zephyr/gap_wid.py
@@ -216,7 +216,14 @@ def hdl_wid_51(desc):
 
 
 def hdl_wid_52(desc):
-    hdl_wid_51(desc)
+    stack = get_stack()
+
+    btp.gap_adv_off()
+    btp.gap_set_conn()
+    btp.gap_set_gendiscov()
+
+    btp.gap_adv_ind_on(ad=stack.gap.ad)
+
     return True
 
 


### PR DESCRIPTION
It is used by GAP/DISC/GENM/BV-04-C.