### PR TITLE
Add rtt2pty feature supporting to auto-pts bot

### DIFF
--- a/bot/zephyr.py
+++ b/bot/zephyr.py
@@ -315,7 +315,7 @@ def run_tests(args, iut_config):
         flush_serial(tty)
         time.sleep(10)
 
-        autoprojects.iutctl.init(args["kernel_image"], tty, args["board_id"], args["board"])
+        autoprojects.iutctl.init(args["kernel_image"], tty, args["board_id"], args["board"], args.get("rtt2pty"))
 
         # Setup project PIXITS
         autoprojects.gap.set_pixits(ptses[0])


### PR DESCRIPTION
Capture RTT logs when 'rtt2pty' is set in AutoPTS configuration. Otherwise, disable rtt2pty feature by default.

The RTT logs (iut-zephyr.log) is archived in the logs.zip.