### PR TITLE
Zephyr: fix L2CAP/COS/CFC/BV-03-C

### DIFF
--- a/wid/l2cap.py
+++ b/wid/l2cap.py
@@ -156,7 +156,7 @@ def hdl_wid_41(desc):
     """
     stack = get_stack()
 
-    btp.l2cap_conn(None, None, stack.l2cap.psm)
+    btp.l2cap_conn(None, None, stack.l2cap.psm, 256)
 
     return True
 


### PR DESCRIPTION
MTU has to be greater than MPS when segmentation is tested.